### PR TITLE
Fix/input alphabet mismatch

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,7 +67,7 @@ pub(super) struct Cli {
     pub(super) gap_handling: GapHandling,
 
     /// Epsilon value for numerical optimisation
-    #[arg(short, long, value_name = "EPSILON", default_value = "1e-2")]
+    #[arg(short, long, value_name = "EPSILON", default_value = "1e-5")]
     pub(super) epsilon: f64,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 
 use log::{debug, info};
 
+use phylo::alphabets::{dna_alphabet, protein_alphabet};
 use phylo::evolutionary_models::FrequencyOptimisation;
 use phylo::io::write_newick_to_file;
 use phylo::likelihood::{ModelSearchCost, TreeSearchCost};
@@ -72,8 +73,22 @@ fn main() -> Result<()> {
         Some(tree_file) => info!("Using tree from {}.", tree_file.display()),
         None => info!("No input tree provided, building NJ tree from sequences."),
     }
+
+    let alphabet = match cfg.model.as_str() {
+        "JC69" | "K80" | "HKY85" | "HKY" | "TN93" | "GTR" => {
+            info!("Assuming DNA sequences");
+            Some(dna_alphabet())
+        }
+        "WAG" | "HIVB" | "BLOSUM" => {
+            info!("Assuming protein sequences");
+            Some(protein_alphabet())
+        }
+        _ => None,
+    };
+
     let info = PhyloInfoBuilder::new(cfg.seq_file)
         .tree_file(cfg.input_tree)
+        .alphabet(alphabet)
         .build()?;
 
     let (cost, tree) = match cfg.gap_handling {


### PR DESCRIPTION
Setting sequence alphabet based on the specified model rather than relying on detection.